### PR TITLE
backend over localhost for docker communication reasons

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,4 +26,4 @@ services:
     depends_on:
       - backend
     environment:
-      - VITE_API_URL=http://localhost:8000
+      - VITE_API_URL=http://backend:8000


### PR DESCRIPTION
the smallest change ever.

use backend over localhost since apparently it should be backend so that the docker containers can communicate